### PR TITLE
Fix for #9: Number-suffixes (".2" in "0.1.2") with a dot are lost when scrubbing a string that contains a number.

### DIFF
--- a/main.js
+++ b/main.js
@@ -64,7 +64,7 @@ define(function (require, exports, module) {
         }
         
         // Support numbers with a suffix like "px" or "%"
-        var extras = /([^\d\-\.]*)(-?[\d\.]+)(.*)/.exec(candidate);
+        var extras = /([^\d\-\.]*)(-?(?:(?:\d*\.)|(?:\d+\.?))\d*)(.*)/.exec(candidate);
         var origStringValue = (extras && extras[2]) || candidate;
         if (isNaN(parseFloat(origStringValue))) {
             return null;

--- a/main.less
+++ b/main.less
@@ -1,0 +1,14 @@
+span.cm-number {
+    pointer-events: auto;
+}
+
+span.cm-number:hover, .everyscrub-changeable-highlight  {
+    border-top-style: dashed;
+    border-bottom-style: dashed;
+    border-color: dark-gray;
+    border-width: 1px;
+}
+
+.everyscrub-ready-to-be-scrubbed {
+    cursor: col-resize;
+}


### PR DESCRIPTION
Strings with numbers with more than one dot "." now preserve the suffix number when being scrubbed.
Achieved by changing the number parsing regex to accept just up to one dot in a number.
