### PR TITLE
Fix for #9: Number-suffixes (".2" in "0.1.2") with a dot are lost when scrubbing a string that contains a number.

### DIFF
--- a/main.js
+++ b/main.js
@@ -64,7 +64,7 @@ define(function (require, exports, module) {
         }
         
         // Support numbers with a suffix like "px" or "%"
-        var extras = /([^\d\-\.]*)(-?[\d\.]+)(.*)/.exec(candidate);
+        var extras = /([^\d\-\.]*)(-?(?:(?:\d*\.)|(?:\d+\.?))\d*)(.*)/.exec(candidate);
         var origStringValue = (extras && extras[2]) || candidate;
         if (isNaN(parseFloat(origStringValue))) {
             return null;


### PR DESCRIPTION
Strings with numbers with more than one dot "." now preserve the suffix number when being scrubbed.
