### PR TITLE
Highlights for scrubbable numbers, partially adresses #6

### DIFF
--- a/main.js
+++ b/main.js
@@ -64,7 +64,7 @@ define(function (require, exports, module) {
         }
         
         // Support numbers with a suffix like "px" or "%"
-        var extras = /([^\d\-\.]*)(-?[\d\.]+)(.*)/.exec(candidate);
+        var extras = /([^\d\-\.]*)(-?(?:(?:\d*\.)|(?:\d+\.?))\d*)(.*)/.exec(candidate);
         var origStringValue = (extras && extras[2]) || candidate;
         if (isNaN(parseFloat(origStringValue))) {
             return null;

--- a/main.less
+++ b/main.less
@@ -1,0 +1,14 @@
+span.cm-number {
+    pointer-events: auto;
+}
+
+span.cm-number:hover, .everyscrub-changeable-highlight  {
+    border-top-style: dashed;
+    border-bottom-style: dashed;
+    border-color: dark-gray;
+    border-width: 1px;
+}
+
+.everyscrub-ready-to-be-scrubbed {
+    cursor: col-resize;
+}


### PR DESCRIPTION
I added a highlight to number-tokens in Javascript code to indicate that they are scrubbable. I didn't choose any of the options in your enhancement #6, since they didn't convince me. Instead I did the following:
- Added a hover style to number tokens, so they are highlighted on mouse-over, indicating that the user can do "something" with them.
- On Cmd/Ctrl-down while hovering over a number the mouse pointer changes to a col-resize cursor; thus, indicating that the user should drag and in which direction the dragging should be
- when the text cursor is inside of the range of a number token and Alt+Shift is pressed the same highlight is added to the focused number as the one that's used for mouse-over, again indicating that this value can now be changed (nudged). 
- The highlights stay active (even after the mouse was moved out of the number) while the number is being changed (scrubbed/nudged)

This pull-request also contains the previous two (fix for #3 and fix for #6). If you need it, I can extract the changes for those two from this branch, but it was a lot easier to just leave it in there.
